### PR TITLE
Add NewCol method to initialize the Col object

### DIFF
--- a/db.go
+++ b/db.go
@@ -637,6 +637,11 @@ type Col struct {
 	Opt  *ColOpt     // options
 }
 
+//NewCol returns a new Col object
+func NewCol(name string, val interface{}, opt *ColOpt) Col {
+	return Col{Name: name, Val: val, Opt: opt}
+}
+
 func (d Col) skipOnInsert() bool {
 	if d.Opt == nil {
 		return false


### PR DESCRIPTION
This is to help remove `go vet` errors when initializing the `Col` type using unkeyed fields
